### PR TITLE
WIP: Allow configuring an Executor without restarting

### DIFF
--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -1,14 +1,16 @@
 package com.liveramp.daemon_lib;
 
+import java.util.concurrent.TimeUnit;
+
 import com.google.common.base.Optional;
-import com.liveramp.daemon_lib.executors.JobletExecutor;
-import com.liveramp.daemon_lib.executors.processes.execution_conditions.postconfig.ConfigBasedExecutionCondition;
-import com.liveramp.daemon_lib.executors.processes.execution_conditions.preconfig.ExecutionCondition;
-import com.liveramp.daemon_lib.utils.DaemonException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
+import com.liveramp.daemon_lib.executors.JobletExecutor;
+import com.liveramp.daemon_lib.executors.processes.execution_conditions.postconfig.ConfigBasedExecutionCondition;
+import com.liveramp.daemon_lib.executors.processes.execution_conditions.preconfig.ExecutionCondition;
+import com.liveramp.daemon_lib.executors.processes.execution_conditions.preconfig.ExecutionConditions;
+import com.liveramp.daemon_lib.utils.DaemonException;
 import com.liveramp.daemon_lib.utils.HostUtil;
 
 public class Daemon<T extends JobletConfig> {
@@ -116,7 +118,7 @@ public class Daemon<T extends JobletConfig> {
   }
 
   protected boolean processNext() {
-    if (executionCondition.canExecute()) {
+    if (ExecutionConditions.and(executor.getDefaultExecutionCondition(), executionCondition).canExecute()) {
       T jobletConfig;
       try {
         lock.lock();

--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -105,6 +105,7 @@ public class Daemon<T extends JobletConfig> {
 
     try {
       while (running) {
+        executor.reloadConfiguration();
         if (!processNext()) {
           silentSleep(options.failureWaitSeconds);
         }
@@ -118,7 +119,6 @@ public class Daemon<T extends JobletConfig> {
   }
 
   protected boolean processNext() {
-    executor.reloadConfiguration();
     if (ExecutionConditions.and(executor.getDefaultExecutionCondition(), executionCondition).canExecute()) {
       T jobletConfig;
       try {

--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -118,6 +118,7 @@ public class Daemon<T extends JobletConfig> {
   }
 
   protected boolean processNext() {
+    executor.reloadConfiguration();
     if (ExecutionConditions.and(executor.getDefaultExecutionCondition(), executionCondition).canExecute()) {
       T jobletConfig;
       try {

--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseDaemonBuilder.java
@@ -115,6 +115,6 @@ public abstract class BaseDaemonBuilder<T extends JobletConfig, K extends BaseDa
   public Daemon<T> build() throws IllegalAccessException, IOException, InstantiationException {
     final JobletExecutor<T> executor = getExecutor();
     LoggingForwardingNotifier notifier = new LoggingForwardingNotifier(this.notifier);
-    return new Daemon<>(identifier, executor, configProducer, onNewConfigCallback, lock, notifier, options, ExecutionConditions.and(executor.getDefaultExecutionCondition(), additionalExecutionCondition), postConfigExecutionCondition);
+    return new Daemon<>(identifier, executor, configProducer, onNewConfigCallback, lock, notifier, options, additionalExecutionCondition, postConfigExecutionCondition);
   }
 }

--- a/src/main/java/com/liveramp/daemon_lib/builders/ForkingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/ForkingDaemonBuilder.java
@@ -43,7 +43,7 @@ public class ForkingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBuil
     successCallback = new JobletCallback.None<>();
     failureCallback = new JobletCallback.None<>();
 
-    executorConfigSupplier = () -> new ForkedJobletExecutor.Config(DEFAULT_MAX_PROCESSES);
+    executorConfigSupplier = null;
   }
 
   public ForkingDaemonBuilder<T> setMaxProcesses(int maxProcesses) {
@@ -75,7 +75,8 @@ public class ForkingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBuil
   @Override
   protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
     final String tmpPath = new File(workingDir, identifier).getPath();
-    final Supplier<ForkedJobletExecutor.Config> compositeConfigSupplier = ExecutorConfigSuppliers.fallingBack(executorConfigSupplier, () -> new ForkedJobletExecutor.Config(maxProcesses));
+    final Supplier<ForkedJobletExecutor.Config> defaultConfigSupplier = () -> new ForkedJobletExecutor.Config(maxProcesses);
+    final Supplier<ForkedJobletExecutor.Config> compositeConfigSupplier = executorConfigSupplier == null ? defaultConfigSupplier : ExecutorConfigSuppliers.fallingBack(executorConfigSupplier, defaultConfigSupplier);
     return JobletExecutors.Forked.get(notifier, tmpPath, jobletFactoryClass, envVariables, successCallback, failureCallback, jobletRunner, compositeConfigSupplier);
   }
 }

--- a/src/main/java/com/liveramp/daemon_lib/builders/ForkingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/ForkingDaemonBuilder.java
@@ -3,6 +3,7 @@ package com.liveramp.daemon_lib.builders;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import com.google.common.collect.Maps;
 import org.jetbrains.annotations.NotNull;
@@ -11,15 +12,16 @@ import com.liveramp.daemon_lib.JobletCallback;
 import com.liveramp.daemon_lib.JobletConfig;
 import com.liveramp.daemon_lib.JobletConfigProducer;
 import com.liveramp.daemon_lib.JobletFactory;
+import com.liveramp.daemon_lib.executors.ForkedJobletExecutor;
 import com.liveramp.daemon_lib.executors.JobletExecutor;
 import com.liveramp.daemon_lib.executors.JobletExecutors;
+import com.liveramp.daemon_lib.executors.config.ExecutorConfigSuppliers;
 import com.liveramp.daemon_lib.executors.forking.ProcessJobletRunner;
 
 public class ForkingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBuilder<T, ForkingDaemonBuilder<T>> {
 
   private final String workingDir;
   private final Class<? extends JobletFactory<T>> jobletFactoryClass;
-  private int maxProcesses;
   private Map<String, String> envVariables;
   private JobletCallback<? super T> successCallback;
   private JobletCallback<? super T> failureCallback;
@@ -27,6 +29,8 @@ public class ForkingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBuil
 
   private static final int DEFAULT_MAX_PROCESSES = 1;
   private static final Map<String, String> DEFAULT_ENV_VARS = Maps.newHashMap();
+  private Supplier<ForkedJobletExecutor.Config> executorConfigSupplier;
+  private int maxProcesses;
 
   public ForkingDaemonBuilder(String workingDir, String identifier, Class<? extends JobletFactory<T>> jobletFactoryClass, JobletConfigProducer<T> configProducer, ProcessJobletRunner jobletRunner) {
     super(identifier, configProducer);
@@ -38,6 +42,8 @@ public class ForkingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBuil
     envVariables = DEFAULT_ENV_VARS;
     successCallback = new JobletCallback.None<>();
     failureCallback = new JobletCallback.None<>();
+
+    executorConfigSupplier = () -> new ForkedJobletExecutor.Config(DEFAULT_MAX_PROCESSES);
   }
 
   public ForkingDaemonBuilder<T> setMaxProcesses(int maxProcesses) {
@@ -60,10 +66,16 @@ public class ForkingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBuil
     return this;
   }
 
+  public ForkingDaemonBuilder<T> setExecutorConfigSupplier(Supplier<ForkedJobletExecutor.Config> executorConfigSupplier) {
+    this.executorConfigSupplier = executorConfigSupplier;
+    return this;
+  }
+
   @NotNull
   @Override
   protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
     final String tmpPath = new File(workingDir, identifier).getPath();
-    return JobletExecutors.Forked.get(notifier, tmpPath, maxProcesses, jobletFactoryClass, envVariables, successCallback, failureCallback, jobletRunner);
+    final Supplier<ForkedJobletExecutor.Config> compositeConfigSupplier = ExecutorConfigSuppliers.fallingBack(executorConfigSupplier, () -> new ForkedJobletExecutor.Config(maxProcesses));
+    return JobletExecutors.Forked.get(notifier, tmpPath, jobletFactoryClass, envVariables, successCallback, failureCallback, jobletRunner, compositeConfigSupplier);
   }
 }

--- a/src/main/java/com/liveramp/daemon_lib/builders/ThreadingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/ThreadingDaemonBuilder.java
@@ -1,7 +1,9 @@
 package com.liveramp.daemon_lib.builders;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 
 import com.liveramp.daemon_lib.JobletCallback;
@@ -10,28 +12,32 @@ import com.liveramp.daemon_lib.JobletConfigProducer;
 import com.liveramp.daemon_lib.JobletFactory;
 import com.liveramp.daemon_lib.executors.JobletExecutor;
 import com.liveramp.daemon_lib.executors.JobletExecutors;
+import com.liveramp.daemon_lib.executors.ThreadedJobletExecutor;
+import com.liveramp.daemon_lib.executors.config.ExecutorConfigSuppliers;
 
 public class ThreadingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBuilder<T, ThreadingDaemonBuilder<T>> {
 
   private final JobletFactory<T> jobletFactory;
   private JobletCallback<T> successCallback;
   private JobletCallback<T> failureCallback;
-  private int maxThreads;
 
   private static final int DEFAULT_MAX_THREADS = 1;
-
+  private Supplier<ThreadedJobletExecutor.Config> executorConfigSupplier;
+  private int maxThreads;
 
   public ThreadingDaemonBuilder(String identifier, JobletFactory<T> jobletFactory, JobletConfigProducer<T> configProducer) {
     super(identifier, configProducer);
     this.jobletFactory = jobletFactory;
 
     this.maxThreads = DEFAULT_MAX_THREADS;
+    this.executorConfigSupplier = () -> new ThreadedJobletExecutor.Config(DEFAULT_MAX_THREADS);
 
     this.successCallback = new JobletCallback.None<>();
     this.failureCallback = new JobletCallback.None<>();
   }
 
   public ThreadingDaemonBuilder<T> setMaxThreads(int maxThreads) {
+    Preconditions.checkArgument(maxThreads > 0);
     this.maxThreads = maxThreads;
     return this;
   }
@@ -46,9 +52,15 @@ public class ThreadingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBu
     return this;
   }
 
+  public ThreadingDaemonBuilder<T> setExecutorConfigSupplier(Supplier<ThreadedJobletExecutor.Config> executorConfigSupplier) {
+    this.executorConfigSupplier = executorConfigSupplier;
+    return this;
+  }
+
   @NotNull
   @Override
   protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
-    return JobletExecutors.Threaded.get(maxThreads, jobletFactory, successCallback, failureCallback);
+    final Supplier<ThreadedJobletExecutor.Config> configSupplier = ExecutorConfigSuppliers.fallingBack(executorConfigSupplier, () -> new ThreadedJobletExecutor.Config(maxThreads));
+    return JobletExecutors.Threaded.get(jobletFactory, successCallback, failureCallback, configSupplier);
   }
 }

--- a/src/main/java/com/liveramp/daemon_lib/executors/BlockingJobletExecutor.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/BlockingJobletExecutor.java
@@ -36,6 +36,11 @@ public class BlockingJobletExecutor<T extends JobletConfig> implements JobletExe
   }
 
   @Override
+  public void reloadConfiguration() {
+
+  }
+
+  @Override
   public void shutdown() {
 
   }

--- a/src/main/java/com/liveramp/daemon_lib/executors/ForkedJobletExecutor.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/ForkedJobletExecutor.java
@@ -98,11 +98,6 @@ public class ForkedJobletExecutor<T extends JobletConfig, M extends ProcessMetad
       this.executorConfigSupplier = () -> new Config(DEFAULT_MAX_PROCESSES);
     }
 
-    public Builder<S, M, Pid> setMaxProcesses(int maxProcesses) {
-      this.executorConfigSupplier = () -> new Config(maxProcesses);
-      return this;
-    }
-
     public Builder<S, M, Pid> setJobletFactoryClass(Class<? extends JobletFactory<? extends S>> jobletFactoryClass) {
       this.jobletFactoryClass = jobletFactoryClass;
       return this;

--- a/src/main/java/com/liveramp/daemon_lib/executors/ForkedJobletExecutor.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/ForkedJobletExecutor.java
@@ -29,6 +29,8 @@ public class ForkedJobletExecutor<T extends JobletConfig, M extends ProcessMetad
   private final JobletCallback<? super T> failureCallback;
   private final Supplier<Config> configSupplier;
 
+  private int numJoblets;
+
   ForkedJobletExecutor(Class<? extends JobletFactory<? extends T>> jobletFactoryClass, JobletConfigStorage<T> configStorage, ProcessController<M, Pid> processController, ProcessJobletRunner<Pid> jobletRunner, MetadataFactory<M> metadataFactory, Map<String, String> envVariables, String workingDir, JobletCallback<? super T> failureCallback, Supplier<Config> configSupplier) {
     this.jobletFactoryClass = jobletFactoryClass;
     this.configStorage = configStorage;
@@ -39,6 +41,8 @@ public class ForkedJobletExecutor<T extends JobletConfig, M extends ProcessMetad
     this.workingDir = workingDir;
     this.failureCallback = failureCallback;
     this.configSupplier = configSupplier;
+
+    this.numJoblets = configSupplier.get().numJoblets;
   }
 
   @Override
@@ -55,7 +59,12 @@ public class ForkedJobletExecutor<T extends JobletConfig, M extends ProcessMetad
 
   @Override
   public ExecutionCondition getDefaultExecutionCondition() {
-    return new DefaultForkedExecutionCondition(processController, configSupplier.get().numJoblets);
+    return new DefaultForkedExecutionCondition(processController, numJoblets);
+  }
+
+  @Override
+  public void reloadConfiguration() {
+    numJoblets = configSupplier.get().numJoblets;
   }
 
   @Override

--- a/src/main/java/com/liveramp/daemon_lib/executors/JobletExecutor.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/JobletExecutor.java
@@ -9,5 +9,7 @@ public interface JobletExecutor<T extends JobletConfig> {
 
   ExecutionCondition getDefaultExecutionCondition();
 
+  void reloadConfiguration();
+
   void shutdown();
 }

--- a/src/main/java/com/liveramp/daemon_lib/executors/JobletExecutors.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/JobletExecutors.java
@@ -77,8 +77,11 @@ public class JobletExecutors {
     public static <T extends JobletConfig> ThreadedJobletExecutor<T> get(JobletFactory<T> jobletFactory, JobletCallback<T> successCallbacks, JobletCallback<T> failureCallbacks, Supplier<ThreadedJobletExecutor.Config> threadedExecutorConfigSupplier) throws IllegalAccessException, InstantiationException {
       Preconditions.checkNotNull(jobletFactory);
 
+      final ThreadedJobletExecutor.Config initialConfig = threadedExecutorConfigSupplier.get();
+      Preconditions.checkState(initialConfig.numJoblets >= 0);
+
       ThreadPoolExecutor threadPool = (ThreadPoolExecutor)Executors.newFixedThreadPool(
-          threadedExecutorConfigSupplier.get().numJoblets,
+          initialConfig.numJoblets == 0 ? 1 : initialConfig.numJoblets,
           new ThreadFactoryBuilder().setNameFormat("joblet-executor-%d").build()
       );
 

--- a/src/main/java/com/liveramp/daemon_lib/executors/JobletExecutors.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/JobletExecutors.java
@@ -77,7 +77,8 @@ public class JobletExecutors {
     public static <T extends JobletConfig> ThreadedJobletExecutor<T> get(JobletFactory<T> jobletFactory, JobletCallback<T> successCallbacks, JobletCallback<T> failureCallbacks, Supplier<ThreadedJobletExecutor.Config> threadedExecutorConfigSupplier) throws IllegalAccessException, InstantiationException {
       Preconditions.checkNotNull(jobletFactory);
 
-      ThreadPoolExecutor threadPool = (ThreadPoolExecutor)Executors.newCachedThreadPool(
+      ThreadPoolExecutor threadPool = (ThreadPoolExecutor)Executors.newFixedThreadPool(
+          threadedExecutorConfigSupplier.get().numJoblets,
           new ThreadFactoryBuilder().setNameFormat("joblet-executor-%d").build()
       );
 

--- a/src/main/java/com/liveramp/daemon_lib/executors/ThreadedJobletExecutor.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/ThreadedJobletExecutor.java
@@ -1,17 +1,20 @@
 package com.liveramp.daemon_lib.executors;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.liveramp.daemon_lib.Joblet;
 import com.liveramp.daemon_lib.JobletCallback;
 import com.liveramp.daemon_lib.JobletConfig;
 import com.liveramp.daemon_lib.JobletFactory;
+import com.liveramp.daemon_lib.executors.config.ExecutorConfig;
 import com.liveramp.daemon_lib.executors.processes.execution_conditions.preconfig.DefaultThreadedExecutionCondition;
 import com.liveramp.daemon_lib.executors.processes.execution_conditions.preconfig.ExecutionCondition;
 import com.liveramp.daemon_lib.utils.DaemonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.Callable;
-import java.util.concurrent.ThreadPoolExecutor;
 
 public class ThreadedJobletExecutor<T extends JobletConfig> implements JobletExecutor<T> {
   private static final Logger LOG = LoggerFactory.getLogger(ThreadedJobletExecutor.class);
@@ -20,12 +23,14 @@ public class ThreadedJobletExecutor<T extends JobletConfig> implements JobletExe
   private final JobletFactory<T> jobletFactory;
   private final JobletCallback<T> successCallback;
   private final JobletCallback<T> failureCallback;
+  private final Supplier<Config> executorConfigSupplier;
 
-  public ThreadedJobletExecutor(ThreadPoolExecutor threadPool, JobletFactory<T> jobletFactory, JobletCallback<T> successCallback, JobletCallback<T> failureCallback) {
+  public ThreadedJobletExecutor(ThreadPoolExecutor threadPool, JobletFactory<T> jobletFactory, JobletCallback<T> successCallback, JobletCallback<T> failureCallback, Supplier<Config> executorConfigSupplier) {
     this.threadPool = threadPool;
     this.jobletFactory = jobletFactory;
     this.successCallback = successCallback;
     this.failureCallback = failureCallback;
+    this.executorConfigSupplier = executorConfigSupplier;
   }
 
   @Override
@@ -48,11 +53,19 @@ public class ThreadedJobletExecutor<T extends JobletConfig> implements JobletExe
 
   @Override
   public ExecutionCondition getDefaultExecutionCondition() {
-    return new DefaultThreadedExecutionCondition(threadPool);
+    return new DefaultThreadedExecutionCondition(threadPool, executorConfigSupplier.get());
   }
 
   @Override
   public void shutdown() {
     threadPool.shutdown();
+  }
+
+  public static class Config implements ExecutorConfig {
+    public final int numJoblets;
+
+    public Config(int numJoblets) {
+      this.numJoblets = numJoblets;
+    }
   }
 }

--- a/src/main/java/com/liveramp/daemon_lib/executors/ThreadedJobletExecutor.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/ThreadedJobletExecutor.java
@@ -53,7 +53,14 @@ public class ThreadedJobletExecutor<T extends JobletConfig> implements JobletExe
 
   @Override
   public ExecutionCondition getDefaultExecutionCondition() {
-    return new DefaultThreadedExecutionCondition(threadPool, executorConfigSupplier.get());
+    return new DefaultThreadedExecutionCondition(threadPool);
+  }
+
+  @Override
+  public void reloadConfiguration() {
+    final Config config = executorConfigSupplier.get();
+    threadPool.setCorePoolSize(config.numJoblets);
+    threadPool.setMaximumPoolSize(config.numJoblets);
   }
 
   @Override

--- a/src/main/java/com/liveramp/daemon_lib/executors/config/ExecutorConfig.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/config/ExecutorConfig.java
@@ -1,0 +1,7 @@
+package com.liveramp.daemon_lib.executors.config;
+
+public interface ExecutorConfig {
+
+  class None implements ExecutorConfig {}
+
+}

--- a/src/main/java/com/liveramp/daemon_lib/executors/config/ExecutorConfigSupplier.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/config/ExecutorConfigSupplier.java
@@ -1,0 +1,25 @@
+package com.liveramp.daemon_lib.executors.config;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class ExecutorConfigSupplier<T extends ExecutorConfig> implements Supplier<T> {
+  private final Function<byte[], T> deserializer;
+  private final Supplier<byte[]> reader;
+
+  public ExecutorConfigSupplier(Function<byte[], T> deserializer, Supplier<byte[]> reader) {
+    this.deserializer = deserializer;
+    this.reader = reader;
+  }
+
+  @Override
+  public T get() {
+    final byte[] bytes = reader.get();
+    return deserializer.apply(bytes);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("\"className\": \"%s\", \"deserializer\": %s, \"reader\": \"%s\"", this.getClass().getSimpleName(), deserializer, reader);
+  }
+}

--- a/src/main/java/com/liveramp/daemon_lib/executors/config/ExecutorConfigSupplier.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/config/ExecutorConfigSupplier.java
@@ -15,7 +15,11 @@ public class ExecutorConfigSupplier<T extends ExecutorConfig> implements Supplie
   @Override
   public T get() {
     final byte[] bytes = reader.get();
-    return deserializer.apply(bytes);
+    if (bytes == null) {
+      return null;
+    } else {
+      return deserializer.apply(bytes);
+    }
   }
 
   @Override

--- a/src/main/java/com/liveramp/daemon_lib/executors/config/ExecutorConfigSuppliers.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/config/ExecutorConfigSuppliers.java
@@ -1,6 +1,9 @@
 package com.liveramp.daemon_lib.executors.config;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
@@ -8,8 +11,17 @@ import java.util.function.Supplier;
 import com.google.common.collect.Lists;
 
 public class ExecutorConfigSuppliers {
-  public static <T extends ExecutorConfig> Supplier<T> standard(Path filename, Class<T> klass) {
-    return new ExecutorConfigSupplier<>(new GsonDeserializer<>(klass), new FileBasedReader(filename));
+  public static final Path DEFAULT_SUB_PATH = Paths.get("default");
+
+  public static <T extends ExecutorConfig> Supplier<T> standard(Path basePath, Class<T> klass) {
+    return new ExecutorConfigSupplier<>(new GsonDeserializer<>(klass), new FileBasedReader(basePath.resolve(DEFAULT_SUB_PATH)));
+  }
+
+  public static <T extends ExecutorConfig> Supplier<T> hostBased(Path basePath, Class<T> klass) throws UnknownHostException {
+    return fallingBack(
+        standard(basePath.resolve(InetAddress.getLocalHost().getHostName()), klass),
+        standard(basePath.resolve(DEFAULT_SUB_PATH), klass)
+    );
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/com/liveramp/daemon_lib/executors/config/ExecutorConfigSuppliers.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/config/ExecutorConfigSuppliers.java
@@ -1,0 +1,22 @@
+package com.liveramp.daemon_lib.executors.config;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+import com.google.common.collect.Lists;
+
+public class ExecutorConfigSuppliers {
+  public static <T extends ExecutorConfig> Supplier<T> standard(Path filename, Class<T> klass) {
+    return new ExecutorConfigSupplier<>(new GsonDeserializer<>(klass), new FileBasedReader(filename));
+  }
+
+  @SuppressWarnings("unchecked")
+  @SafeVarargs
+  public static <T extends ExecutorConfig> Supplier<T> fallingBack(Supplier<T> first, Supplier<T>... rest) {
+    final List<Supplier<T>> suppliers = Lists.newArrayList(first);
+    suppliers.addAll(Arrays.asList(rest));
+    return new FallbackSupplier<>(suppliers);
+  }
+}

--- a/src/main/java/com/liveramp/daemon_lib/executors/config/FallbackSupplier.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/config/FallbackSupplier.java
@@ -1,0 +1,40 @@
+package com.liveramp.daemon_lib.executors.config;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FallbackSupplier<T> implements Supplier<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(FallbackSupplier.class);
+
+  private final List<Supplier<T>> suppliers;
+
+  public FallbackSupplier(List<Supplier<T>> suppliers) {
+    this.suppliers = suppliers;
+  }
+
+  @Override
+  public T get() {
+    for (Supplier<T> supplier : suppliers) {
+      try {
+        final T t = supplier.get();
+        if (t != null) {
+          return t;
+        } else {
+          LOG.debug("Supplier {} doesn't have config", supplier);
+        }
+      } catch (Exception e) {
+        LOG.warn("Supplier {} threw error {}", supplier, e);
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("{\"className\": \"%s\", \"suppliers\": %s}", this.getClass().getSimpleName(), this.suppliers);
+  }
+}

--- a/src/main/java/com/liveramp/daemon_lib/executors/config/FileBasedReader.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/config/FileBasedReader.java
@@ -1,0 +1,42 @@
+package com.liveramp.daemon_lib.executors.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+public class FileBasedReader implements Supplier<byte[]> {
+
+  private final Path filePath;
+
+  public FileBasedReader(Path filePath) {
+    this.filePath = filePath;
+  }
+
+  @Override
+  public byte[] get() {
+    int tries = 0;
+
+    Exception x = null;
+    while (tries < 5) {
+      tries++;
+      try {
+        return Files.readAllBytes(filePath);
+      } catch (IOException e) {
+        x = e;
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e1) {
+          throw new RuntimeException(e1);
+        }
+      }
+    }
+
+    throw new RuntimeException(x);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("{\"className\": \"%s\", \"path\": \"%s\"}", this.getClass().getSimpleName(), this.filePath);
+  }
+}

--- a/src/main/java/com/liveramp/daemon_lib/executors/config/GsonDeserializer.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/config/GsonDeserializer.java
@@ -15,8 +15,6 @@ public class GsonDeserializer<T> implements Function<byte[], T> {
     this.gson = new Gson();
   }
 
-
-
   @Override
   public T apply(byte[] bytes) {
     return gson.fromJson(new String(bytes, Charset.forName("UTF-8")), klass);

--- a/src/main/java/com/liveramp/daemon_lib/executors/config/GsonDeserializer.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/config/GsonDeserializer.java
@@ -1,0 +1,29 @@
+package com.liveramp.daemon_lib.executors.config;
+
+import java.nio.charset.Charset;
+import java.util.function.Function;
+
+import com.google.gson.Gson;
+
+public class GsonDeserializer<T> implements Function<byte[], T> {
+
+  private final Class<T> klass;
+  private final Gson gson;
+
+  public GsonDeserializer(Class<T> klass) {
+    this.klass = klass;
+    this.gson = new Gson();
+  }
+
+
+
+  @Override
+  public T apply(byte[] bytes) {
+    return gson.fromJson(new String(bytes, Charset.forName("UTF-8")), klass);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("{\"className\": \"%s\", \"classBeingDeserializedTo\": \"%s\"}", this.getClass().getSimpleName(), klass.getCanonicalName());
+  }
+}

--- a/src/main/java/com/liveramp/daemon_lib/executors/processes/execution_conditions/preconfig/DefaultThreadedExecutionCondition.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/processes/execution_conditions/preconfig/DefaultThreadedExecutionCondition.java
@@ -2,15 +2,19 @@ package com.liveramp.daemon_lib.executors.processes.execution_conditions.preconf
 
 import java.util.concurrent.ThreadPoolExecutor;
 
+import com.liveramp.daemon_lib.executors.ThreadedJobletExecutor;
+
 public class DefaultThreadedExecutionCondition implements ExecutionCondition {
   private final ThreadPoolExecutor threadPool;
+  private final ThreadedJobletExecutor.Config threadedExecutorConfig;
 
-  public DefaultThreadedExecutionCondition(ThreadPoolExecutor threadPool) {
+  public DefaultThreadedExecutionCondition(ThreadPoolExecutor threadPool, ThreadedJobletExecutor.Config threadedExecutorConfig) {
     this.threadPool = threadPool;
+    this.threadedExecutorConfig = threadedExecutorConfig;
   }
 
   @Override
   public boolean canExecute() {
-    return threadPool.getActiveCount() < threadPool.getMaximumPoolSize();
+    return threadPool.getActiveCount() < threadedExecutorConfig.numJoblets;
   }
 }

--- a/src/main/java/com/liveramp/daemon_lib/executors/processes/execution_conditions/preconfig/DefaultThreadedExecutionCondition.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/processes/execution_conditions/preconfig/DefaultThreadedExecutionCondition.java
@@ -2,19 +2,15 @@ package com.liveramp.daemon_lib.executors.processes.execution_conditions.preconf
 
 import java.util.concurrent.ThreadPoolExecutor;
 
-import com.liveramp.daemon_lib.executors.ThreadedJobletExecutor;
-
 public class DefaultThreadedExecutionCondition implements ExecutionCondition {
   private final ThreadPoolExecutor threadPool;
-  private final ThreadedJobletExecutor.Config threadedExecutorConfig;
 
-  public DefaultThreadedExecutionCondition(ThreadPoolExecutor threadPool, ThreadedJobletExecutor.Config threadedExecutorConfig) {
+  public DefaultThreadedExecutionCondition(ThreadPoolExecutor threadPool) {
     this.threadPool = threadPool;
-    this.threadedExecutorConfig = threadedExecutorConfig;
   }
 
   @Override
   public boolean canExecute() {
-    return threadPool.getActiveCount() < threadedExecutorConfig.numJoblets;
+    return threadPool.getActiveCount() < threadPool.getMaximumPoolSize();
   }
 }

--- a/src/test/java/com/liveramp/daemon_lib/TestDaemon.java
+++ b/src/test/java/com/liveramp/daemon_lib/TestDaemon.java
@@ -1,13 +1,14 @@
 package com.liveramp.daemon_lib;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
 import com.liveramp.daemon_lib.built_in.NoOpDaemonLock;
 import com.liveramp.daemon_lib.executors.JobletExecutor;
 import com.liveramp.daemon_lib.executors.processes.execution_conditions.postconfig.ConfigBasedExecutionCondition;
 import com.liveramp.daemon_lib.executors.processes.execution_conditions.preconfig.ExecutionCondition;
 import com.liveramp.daemon_lib.utils.DaemonException;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -37,6 +38,7 @@ public class TestDaemon extends DaemonLibTestCase {
   @Test
   public void executeConfig() throws DaemonException {
     Mockito.when(executionCondition.canExecute()).thenReturn(true);
+    Mockito.when(executor.getDefaultExecutionCondition()).thenReturn(executionCondition);
     Mockito.when(configBasedExecutionCondition.apply(config)).thenReturn(true);
     Mockito.when(configProducer.getNextConfig()).thenReturn(config);
 
@@ -48,6 +50,7 @@ public class TestDaemon extends DaemonLibTestCase {
   @Test
   public void executionUnavailable() throws DaemonException {
     Mockito.when(executionCondition.canExecute()).thenReturn(false);
+    Mockito.when(executor.getDefaultExecutionCondition()).thenReturn(executionCondition);
     Mockito.when(configProducer.getNextConfig()).thenReturn(config);
 
     daemon.processNext();
@@ -58,6 +61,7 @@ public class TestDaemon extends DaemonLibTestCase {
   @Test
   public void noNextConfig() throws DaemonException {
     Mockito.when(executionCondition.canExecute()).thenReturn(false);
+    Mockito.when(executor.getDefaultExecutionCondition()).thenReturn(executionCondition);
     Mockito.when(configProducer.getNextConfig()).thenReturn(null);
 
     daemon.processNext();

--- a/src/test/java/com/liveramp/daemon_lib/executors/TestForkedJobletExecutor.java
+++ b/src/test/java/com/liveramp/daemon_lib/executors/TestForkedJobletExecutor.java
@@ -50,7 +50,7 @@ public class TestForkedJobletExecutor extends DaemonLibTestCase {
     this.processController = Mockito.mock(ProcessController.class);
     this.jobletRunner = Mockito.mock(JarBasedProcessJobletRunner.class);
     this.metadataFactory = Mockito.mock(MetadataFactory.class);
-    this.executor = new ForkedJobletExecutor<>(MAX_PROCESSES, MockJobletFactory.class, configStorage, processController, jobletRunner, metadataFactory, Maps.<String, String>newHashMap(), TEST_ROOT, new JobletCallback.None<>());
+    this.executor = new ForkedJobletExecutor<>(MockJobletFactory.class, configStorage, processController, jobletRunner, metadataFactory, Maps.<String, String>newHashMap(), TEST_ROOT, new JobletCallback.None<>(), () -> new ForkedJobletExecutor.Config(MAX_PROCESSES));
 
     this.config = Mockito.mock(JobletConfig.class);
   }

--- a/src/test/java/com/liveramp/daemon_lib/executors/TestThreadedJobletExecutor.java
+++ b/src/test/java/com/liveramp/daemon_lib/executors/TestThreadedJobletExecutor.java
@@ -38,7 +38,7 @@ public class TestThreadedJobletExecutor extends DaemonLibTestCase {
     factory = mock(JobletFactory.class, RETURNS_DEEP_STUBS);
     successCallback = mock(JobletCallback.class);
     failureCallback = mock(JobletCallback.class);
-    jobletExecutor = new ThreadedJobletExecutor<>(pool, factory, successCallback, failureCallback);
+    jobletExecutor = new ThreadedJobletExecutor<>(pool, factory, successCallback, failureCallback, () -> new ThreadedJobletExecutor.Config(2));
   }
 
   @After
@@ -95,7 +95,7 @@ public class TestThreadedJobletExecutor extends DaemonLibTestCase {
       }
     });
 
-    final DefaultThreadedExecutionCondition defaultThreadedExecutionCondition = new DefaultThreadedExecutionCondition(pool);
+    final DefaultThreadedExecutionCondition defaultThreadedExecutionCondition = new DefaultThreadedExecutionCondition(pool, new ThreadedJobletExecutor.Config(2));
 
     Assert.assertTrue(defaultThreadedExecutionCondition.canExecute());
     jobletExecutor.execute(config);

--- a/src/test/java/com/liveramp/daemon_lib/executors/TestThreadedJobletExecutor.java
+++ b/src/test/java/com/liveramp/daemon_lib/executors/TestThreadedJobletExecutor.java
@@ -95,7 +95,7 @@ public class TestThreadedJobletExecutor extends DaemonLibTestCase {
       }
     });
 
-    final DefaultThreadedExecutionCondition defaultThreadedExecutionCondition = new DefaultThreadedExecutionCondition(pool, new ThreadedJobletExecutor.Config(2));
+    final DefaultThreadedExecutionCondition defaultThreadedExecutionCondition = new DefaultThreadedExecutionCondition(pool);
 
     Assert.assertTrue(defaultThreadedExecutionCondition.canExecute());
     jobletExecutor.execute(config);


### PR DESCRIPTION
This PR is to add a means to configure a `Daemon` `ForkedJobletExecutor` or `ThreadedJobletExecutor` without having to restart the `Daemon`. This is particularly useful to rapidly 'sink' `Daemon`s when you want them to just handle all existing tasks and then stop.

For the `ThreadedJobletExecutor`, we now resize the pool every time the config changes.

The default implementations add the ability to add on a configuration file that's JSON-encoded. The config file will first be tried before the programmatic settings. There's also the trivial ZK implementation in a different PR. ZK allows atomic znode editing so it needn't have the ugly retry logic that files have here.

Everything from names to API is up for change so please comment.