### PR TITLE
Base Forking, Threading and Blocking Daemon Builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+
+jdk:
+  - oraclejdk8
+
+notifications:
+  email: false

--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -73,12 +73,12 @@ public class Daemon<T extends JobletConfig> {
   private final Options options;
 
   private boolean running;
-  private final JobletCallback<T> preExecutionCallback;
+  private final JobletCallback<? super T> preExecutionCallback;
   private DaemonLock lock;
   private final ExecutionCondition executionCondition;
   private final ConfigBasedExecutionCondition<T> configBasedExecutionCondition;
 
-  public Daemon(String identifier, JobletExecutor<T> executor, JobletConfigProducer<T> configProducer, JobletCallback<T> preExecutionCallback, DaemonLock lock, DaemonNotifier notifier, Options options, ExecutionCondition executionCondition, ConfigBasedExecutionCondition<T> configBasedExecutionCondition) {
+  public Daemon(String identifier, JobletExecutor<T> executor, JobletConfigProducer<T> configProducer, JobletCallback<? super T> preExecutionCallback, DaemonLock lock, DaemonNotifier notifier, Options options, ExecutionCondition executionCondition, ConfigBasedExecutionCondition<T> configBasedExecutionCondition) {
     this.preExecutionCallback = preExecutionCallback;
     this.executionCondition = executionCondition;
     this.configBasedExecutionCondition = configBasedExecutionCondition;

--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseBlockingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseBlockingDaemonBuilder.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.liveramp.daemon_lib.JobletCallback;
 import com.liveramp.daemon_lib.JobletConfig;
 import com.liveramp.daemon_lib.JobletConfigProducer;
 import com.liveramp.daemon_lib.JobletFactory;
@@ -14,25 +13,10 @@ import com.liveramp.daemon_lib.executors.JobletExecutors;
 public abstract class BaseBlockingDaemonBuilder<T extends JobletConfig, E extends BaseBlockingDaemonBuilder<T, E>> extends BaseDaemonBuilder<T, E> {
 
   private final JobletFactory<T> jobletFactory;
-  private JobletCallback<T> successCallback;
-  private JobletCallback<T> failureCallback;
 
   protected BaseBlockingDaemonBuilder(String identifier, JobletFactory<T> jobletFactory, JobletConfigProducer<T> configProducer) {
     super(identifier, configProducer);
     this.jobletFactory = jobletFactory;
-
-    this.successCallback = new JobletCallback.None<>();
-    this.failureCallback = new JobletCallback.None<>();
-  }
-
-  public E setSuccessCallback(JobletCallback<T> callback) {
-    this.successCallback = callback;
-    return self();
-  }
-
-  public E setFailureCallback(JobletCallback<T> callback) {
-    this.failureCallback = callback;
-    return self();
   }
 
   @NotNull

--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseBlockingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseBlockingDaemonBuilder.java
@@ -1,0 +1,44 @@
+package com.liveramp.daemon_lib.builders;
+
+import java.io.IOException;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.liveramp.daemon_lib.JobletCallback;
+import com.liveramp.daemon_lib.JobletConfig;
+import com.liveramp.daemon_lib.JobletConfigProducer;
+import com.liveramp.daemon_lib.JobletFactory;
+import com.liveramp.daemon_lib.executors.JobletExecutor;
+import com.liveramp.daemon_lib.executors.JobletExecutors;
+
+public abstract class BaseBlockingDaemonBuilder<T extends JobletConfig, E extends BaseBlockingDaemonBuilder<T, E>> extends BaseDaemonBuilder<T, E> {
+
+  private final JobletFactory<T> jobletFactory;
+  private JobletCallback<T> successCallback;
+  private JobletCallback<T> failureCallback;
+
+  protected BaseBlockingDaemonBuilder(String identifier, JobletFactory<T> jobletFactory, JobletConfigProducer<T> configProducer) {
+    super(identifier, configProducer);
+    this.jobletFactory = jobletFactory;
+
+    this.successCallback = new JobletCallback.None<>();
+    this.failureCallback = new JobletCallback.None<>();
+  }
+
+  public E setSuccessCallback(JobletCallback<T> callback) {
+    this.successCallback = callback;
+    return self();
+  }
+
+  public E setFailureCallback(JobletCallback<T> callback) {
+    this.failureCallback = callback;
+    return self();
+  }
+
+  @NotNull
+  @Override
+  protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
+    return JobletExecutors.Blocking.get(jobletFactory, successCallback, failureCallback);
+  }
+
+}

--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseDaemonBuilder.java
@@ -24,7 +24,9 @@ public abstract class BaseDaemonBuilder<T extends JobletConfig, K extends BaseDa
   private final JobletConfigProducer<T> configProducer;
   protected DaemonNotifier notifier;
   private final Daemon.Options options;
-  private JobletCallback<T> onNewConfigCallback;
+  private JobletCallback<? super T> onNewConfigCallback;
+  protected JobletCallback<? super T> successCallback;
+  protected JobletCallback<? super T> failureCallback;
   private DaemonLock lock;
   protected ExecutionCondition additionalExecutionCondition = ExecutionConditions.alwaysExecute();
   protected ConfigBasedExecutionCondition<T> postConfigExecutionCondition = ConfigBasedExecutionConditions.alwaysExecute();
@@ -33,6 +35,8 @@ public abstract class BaseDaemonBuilder<T extends JobletConfig, K extends BaseDa
     this.identifier = identifier;
     this.configProducer = configProducer;
     this.onNewConfigCallback = new JobletCallback.None<>();
+    this.successCallback = new JobletCallback.None<>();
+    this.failureCallback = new JobletCallback.None<>();
     this.lock = new NoOpDaemonLock();
 
     this.options = new Daemon.Options();
@@ -79,8 +83,24 @@ public abstract class BaseDaemonBuilder<T extends JobletConfig, K extends BaseDa
   /**
    * The callback that should be immediately after a new config is produced.
    */
-  public K setOnNewConfigCallback(JobletCallback<T> callback) {
+  public K setOnNewConfigCallback(JobletCallback<? super T> callback) {
     this.onNewConfigCallback = callback;
+    return self();
+  }
+
+  /**
+   * The callback that gets executed when the joblet succeeds.
+   */
+  public K setSuccessCallback(JobletCallback<? super T> callback) {
+    this.successCallback = callback;
+    return self();
+  }
+
+  /**
+   * The callback that gets executed when the joblet fails.
+   */
+  public K setFailureCallback(JobletCallback<? super T> callback) {
+    this.failureCallback = callback;
     return self();
   }
 

--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseDaemonBuilder.java
@@ -103,10 +103,7 @@ public abstract class BaseDaemonBuilder<T extends JobletConfig, K extends BaseDa
     return self();
   }
 
-  @SuppressWarnings("unchecked")
-  private K self() {
-    return (K)this;
-  }
+  protected abstract K self();
 
   @NotNull
   protected abstract JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException;

--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseForkingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseForkingDaemonBuilder.java
@@ -21,8 +21,6 @@ public abstract class BaseForkingDaemonBuilder<T extends JobletConfig, E extends
   private final Class<? extends JobletFactory<T>> jobletFactoryClass;
   private int maxProcesses;
   private Map<String, String> envVariables;
-  private JobletCallback<? super T> successCallback;
-  private JobletCallback<? super T> failureCallback;
   private ProcessJobletRunner jobletRunner;
 
   private static final int DEFAULT_MAX_PROCESSES = 1;
@@ -36,8 +34,6 @@ public abstract class BaseForkingDaemonBuilder<T extends JobletConfig, E extends
 
     maxProcesses = DEFAULT_MAX_PROCESSES;
     envVariables = DEFAULT_ENV_VARS;
-    successCallback = new JobletCallback.None<>();
-    failureCallback = new JobletCallback.None<>();
   }
 
   public E setMaxProcesses(int maxProcesses) {
@@ -47,16 +43,6 @@ public abstract class BaseForkingDaemonBuilder<T extends JobletConfig, E extends
 
   public E addToEnvironmentVariables(String envVar, String value) {
     this.envVariables.put(envVar, value);
-    return self();
-  }
-
-  public E setSuccessCallback(JobletCallback<? super T> callback) {
-    this.successCallback = callback;
-    return self();
-  }
-
-  public E setFailureCallback(JobletCallback<? super T> callback) {
-    this.failureCallback = callback;
     return self();
   }
 

--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseForkingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseForkingDaemonBuilder.java
@@ -1,0 +1,70 @@
+package com.liveramp.daemon_lib.builders;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+import org.jetbrains.annotations.NotNull;
+
+import com.liveramp.daemon_lib.JobletCallback;
+import com.liveramp.daemon_lib.JobletConfig;
+import com.liveramp.daemon_lib.JobletConfigProducer;
+import com.liveramp.daemon_lib.JobletFactory;
+import com.liveramp.daemon_lib.executors.JobletExecutor;
+import com.liveramp.daemon_lib.executors.JobletExecutors;
+import com.liveramp.daemon_lib.executors.forking.ProcessJobletRunner;
+
+public abstract class BaseForkingDaemonBuilder<T extends JobletConfig, E extends BaseForkingDaemonBuilder<T, E>> extends BaseDaemonBuilder<T, E> {
+
+  private final String workingDir;
+  private final Class<? extends JobletFactory<T>> jobletFactoryClass;
+  private int maxProcesses;
+  private Map<String, String> envVariables;
+  private JobletCallback<? super T> successCallback;
+  private JobletCallback<? super T> failureCallback;
+  private ProcessJobletRunner jobletRunner;
+
+  private static final int DEFAULT_MAX_PROCESSES = 1;
+  private static final Map<String, String> DEFAULT_ENV_VARS = Maps.newHashMap();
+
+  protected BaseForkingDaemonBuilder(String workingDir, String identifier, Class<? extends JobletFactory<T>> jobletFactoryClass, JobletConfigProducer<T> configProducer, ProcessJobletRunner jobletRunner) {
+    super(identifier, configProducer);
+    this.workingDir = workingDir;
+    this.jobletFactoryClass = jobletFactoryClass;
+    this.jobletRunner = jobletRunner;
+
+    maxProcesses = DEFAULT_MAX_PROCESSES;
+    envVariables = DEFAULT_ENV_VARS;
+    successCallback = new JobletCallback.None<>();
+    failureCallback = new JobletCallback.None<>();
+  }
+
+  public E setMaxProcesses(int maxProcesses) {
+    this.maxProcesses = maxProcesses;
+    return self();
+  }
+
+  public E addToEnvironmentVariables(String envVar, String value) {
+    this.envVariables.put(envVar, value);
+    return self();
+  }
+
+  public E setSuccessCallback(JobletCallback<? super T> callback) {
+    this.successCallback = callback;
+    return self();
+  }
+
+  public E setFailureCallback(JobletCallback<? super T> callback) {
+    this.failureCallback = callback;
+    return self();
+  }
+
+  @NotNull
+  @Override
+  protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
+    final String tmpPath = new File(workingDir, identifier).getPath();
+    return JobletExecutors.Forked.get(notifier, tmpPath, maxProcesses, jobletFactoryClass, envVariables, successCallback, failureCallback, jobletRunner);
+  }
+
+}

--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseThreadingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseThreadingDaemonBuilder.java
@@ -14,8 +14,6 @@ import com.liveramp.daemon_lib.executors.JobletExecutors;
 public abstract class BaseThreadingDaemonBuilder<T extends JobletConfig, E extends BaseThreadingDaemonBuilder<T, E>> extends BaseDaemonBuilder<T, E> {
 
   private final JobletFactory<T> jobletFactory;
-  private JobletCallback<T> successCallback;
-  private JobletCallback<T> failureCallback;
   private int maxThreads;
 
   private static final int DEFAULT_MAX_THREADS = 1;
@@ -25,23 +23,10 @@ public abstract class BaseThreadingDaemonBuilder<T extends JobletConfig, E exten
     this.jobletFactory = jobletFactory;
 
     this.maxThreads = DEFAULT_MAX_THREADS;
-
-    this.successCallback = new JobletCallback.None<>();
-    this.failureCallback = new JobletCallback.None<>();
   }
 
   public BaseThreadingDaemonBuilder<T, E> setMaxThreads(int maxThreads) {
     this.maxThreads = maxThreads;
-    return self();
-  }
-
-  public BaseThreadingDaemonBuilder<T, E> setSuccessCallback(JobletCallback<T> successCallback) {
-    this.successCallback = successCallback;
-    return self();
-  }
-
-  public BaseThreadingDaemonBuilder<T, E> setFailureCallback(JobletCallback<T> failureCallback) {
-    this.failureCallback = failureCallback;
     return self();
   }
 

--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseThreadingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseThreadingDaemonBuilder.java
@@ -1,0 +1,54 @@
+package com.liveramp.daemon_lib.builders;
+
+import java.io.IOException;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.liveramp.daemon_lib.JobletCallback;
+import com.liveramp.daemon_lib.JobletConfig;
+import com.liveramp.daemon_lib.JobletConfigProducer;
+import com.liveramp.daemon_lib.JobletFactory;
+import com.liveramp.daemon_lib.executors.JobletExecutor;
+import com.liveramp.daemon_lib.executors.JobletExecutors;
+
+public abstract class BaseThreadingDaemonBuilder<T extends JobletConfig, E extends BaseThreadingDaemonBuilder<T, E>> extends BaseDaemonBuilder<T, E> {
+
+  private final JobletFactory<T> jobletFactory;
+  private JobletCallback<T> successCallback;
+  private JobletCallback<T> failureCallback;
+  private int maxThreads;
+
+  private static final int DEFAULT_MAX_THREADS = 1;
+
+  public BaseThreadingDaemonBuilder(String identifier, JobletFactory<T> jobletFactory, JobletConfigProducer<T> configProducer) {
+    super(identifier, configProducer);
+    this.jobletFactory = jobletFactory;
+
+    this.maxThreads = DEFAULT_MAX_THREADS;
+
+    this.successCallback = new JobletCallback.None<>();
+    this.failureCallback = new JobletCallback.None<>();
+  }
+
+  public BaseThreadingDaemonBuilder<T, E> setMaxThreads(int maxThreads) {
+    this.maxThreads = maxThreads;
+    return self();
+  }
+
+  public BaseThreadingDaemonBuilder<T, E> setSuccessCallback(JobletCallback<T> successCallback) {
+    this.successCallback = successCallback;
+    return self();
+  }
+
+  public BaseThreadingDaemonBuilder<T, E> setFailureCallback(JobletCallback<T> failureCallback) {
+    this.failureCallback = failureCallback;
+    return self();
+  }
+
+  @NotNull
+  @Override
+  protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
+    return JobletExecutors.Threaded.get(maxThreads, jobletFactory, successCallback, failureCallback);
+  }
+
+}

--- a/src/main/java/com/liveramp/daemon_lib/builders/BlockingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BlockingDaemonBuilder.java
@@ -1,45 +1,16 @@
 package com.liveramp.daemon_lib.builders;
 
-import java.io.IOException;
-
-import org.jetbrains.annotations.NotNull;
-
-import com.liveramp.daemon_lib.JobletCallback;
 import com.liveramp.daemon_lib.JobletConfig;
 import com.liveramp.daemon_lib.JobletConfigProducer;
 import com.liveramp.daemon_lib.JobletFactory;
-import com.liveramp.daemon_lib.executors.JobletExecutor;
-import com.liveramp.daemon_lib.executors.JobletExecutors;
 
-public class BlockingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBuilder<T, BlockingDaemonBuilder<T>> {
-
-  private final JobletFactory<T> jobletFactory;
-
-
-  private JobletCallback<T> successCallback;
-  private JobletCallback<T> failureCallback;
-
+public class BlockingDaemonBuilder<T extends JobletConfig> extends BaseBlockingDaemonBuilder<T, BlockingDaemonBuilder<T>> {
   public BlockingDaemonBuilder(String identifier, JobletFactory<T> jobletFactory, JobletConfigProducer<T> configProducer) {
-    super(identifier, configProducer);
-    this.jobletFactory = jobletFactory;
-
-    this.successCallback = new JobletCallback.None<>();
-    this.failureCallback = new JobletCallback.None<>();
+    super(identifier, jobletFactory, configProducer);
   }
 
-  public BlockingDaemonBuilder<T> setSuccessCallback(JobletCallback<T> callback) {
-    this.successCallback = callback;
-    return this;
-  }
-
-  public BlockingDaemonBuilder<T> setFailureCallback(JobletCallback<T> callback) {
-    this.failureCallback = callback;
-    return this;
-  }
-
-  @NotNull
   @Override
-  protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
-    return JobletExecutors.Blocking.get(jobletFactory, successCallback, failureCallback);
+  protected BlockingDaemonBuilder<T> self() {
+    return this;
   }
 }

--- a/src/main/java/com/liveramp/daemon_lib/builders/ForkingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/ForkingDaemonBuilder.java
@@ -1,69 +1,17 @@
 package com.liveramp.daemon_lib.builders;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
-
-import com.google.common.collect.Maps;
-import org.jetbrains.annotations.NotNull;
-
-import com.liveramp.daemon_lib.JobletCallback;
 import com.liveramp.daemon_lib.JobletConfig;
 import com.liveramp.daemon_lib.JobletConfigProducer;
 import com.liveramp.daemon_lib.JobletFactory;
-import com.liveramp.daemon_lib.executors.JobletExecutor;
-import com.liveramp.daemon_lib.executors.JobletExecutors;
 import com.liveramp.daemon_lib.executors.forking.ProcessJobletRunner;
 
-public class ForkingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBuilder<T, ForkingDaemonBuilder<T>> {
-
-  private final String workingDir;
-  private final Class<? extends JobletFactory<T>> jobletFactoryClass;
-  private int maxProcesses;
-  private Map<String, String> envVariables;
-  private JobletCallback<? super T> successCallback;
-  private JobletCallback<? super T> failureCallback;
-  private ProcessJobletRunner jobletRunner;
-
-  private static final int DEFAULT_MAX_PROCESSES = 1;
-  private static final Map<String, String> DEFAULT_ENV_VARS = Maps.newHashMap();
-
+public class ForkingDaemonBuilder<T extends JobletConfig> extends BaseForkingDaemonBuilder<T, ForkingDaemonBuilder<T>> {
   public ForkingDaemonBuilder(String workingDir, String identifier, Class<? extends JobletFactory<T>> jobletFactoryClass, JobletConfigProducer<T> configProducer, ProcessJobletRunner jobletRunner) {
-    super(identifier, configProducer);
-    this.workingDir = workingDir;
-    this.jobletFactoryClass = jobletFactoryClass;
-    this.jobletRunner = jobletRunner;
-
-    maxProcesses = DEFAULT_MAX_PROCESSES;
-    envVariables = DEFAULT_ENV_VARS;
-    successCallback = new JobletCallback.None<>();
-    failureCallback = new JobletCallback.None<>();
+    super(workingDir, identifier, jobletFactoryClass, configProducer, jobletRunner);
   }
 
-  public ForkingDaemonBuilder<T> setMaxProcesses(int maxProcesses) {
-    this.maxProcesses = maxProcesses;
-    return this;
-  }
-
-  public ForkingDaemonBuilder<T> addToEnvironmentVariables(String envVar, String value) {
-    this.envVariables.put(envVar, value);
-    return this;
-  }
-
-  public ForkingDaemonBuilder<T> setSuccessCallback(JobletCallback<? super T> callback) {
-    this.successCallback = callback;
-    return this;
-  }
-
-  public ForkingDaemonBuilder<T> setFailureCallback(JobletCallback<? super T> callback) {
-    this.failureCallback = callback;
-    return this;
-  }
-
-  @NotNull
   @Override
-  protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
-    final String tmpPath = new File(workingDir, identifier).getPath();
-    return JobletExecutors.Forked.get(notifier, tmpPath, maxProcesses, jobletFactoryClass, envVariables, successCallback, failureCallback, jobletRunner);
+  protected ForkingDaemonBuilder<T> self() {
+    return this;
   }
 }

--- a/src/main/java/com/liveramp/daemon_lib/builders/ThreadingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/ThreadingDaemonBuilder.java
@@ -1,54 +1,16 @@
 package com.liveramp.daemon_lib.builders;
 
-import java.io.IOException;
-
-import org.jetbrains.annotations.NotNull;
-
-import com.liveramp.daemon_lib.JobletCallback;
 import com.liveramp.daemon_lib.JobletConfig;
 import com.liveramp.daemon_lib.JobletConfigProducer;
 import com.liveramp.daemon_lib.JobletFactory;
-import com.liveramp.daemon_lib.executors.JobletExecutor;
-import com.liveramp.daemon_lib.executors.JobletExecutors;
 
-public class ThreadingDaemonBuilder<T extends JobletConfig> extends BaseDaemonBuilder<T, ThreadingDaemonBuilder<T>> {
-
-  private final JobletFactory<T> jobletFactory;
-  private JobletCallback<T> successCallback;
-  private JobletCallback<T> failureCallback;
-  private int maxThreads;
-
-  private static final int DEFAULT_MAX_THREADS = 1;
-
-
+public class ThreadingDaemonBuilder<T extends JobletConfig> extends BaseThreadingDaemonBuilder<T, ThreadingDaemonBuilder<T>> {
   public ThreadingDaemonBuilder(String identifier, JobletFactory<T> jobletFactory, JobletConfigProducer<T> configProducer) {
-    super(identifier, configProducer);
-    this.jobletFactory = jobletFactory;
-
-    this.maxThreads = DEFAULT_MAX_THREADS;
-
-    this.successCallback = new JobletCallback.None<>();
-    this.failureCallback = new JobletCallback.None<>();
+    super(identifier, jobletFactory, configProducer);
   }
 
-  public ThreadingDaemonBuilder<T> setMaxThreads(int maxThreads) {
-    this.maxThreads = maxThreads;
-    return this;
-  }
-
-  public ThreadingDaemonBuilder<T> setSuccessCallback(JobletCallback<T> successCallback) {
-    this.successCallback = successCallback;
-    return this;
-  }
-
-  public ThreadingDaemonBuilder<T> setFailureCallback(JobletCallback<T> failureCallback) {
-    this.failureCallback = failureCallback;
-    return this;
-  }
-
-  @NotNull
   @Override
-  protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
-    return JobletExecutors.Threaded.get(maxThreads, jobletFactory, successCallback, failureCallback);
+  protected ThreadingDaemonBuilder<T> self() {
+    return this;
   }
 }

--- a/src/main/java/com/liveramp/daemon_lib/executors/JobletExecutors.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/JobletExecutors.java
@@ -39,7 +39,7 @@ public class JobletExecutors {
   public static class Forked {
     private static final int DEFAULT_POLL_DELAY = 1000;
 
-    public static <T extends JobletConfig> ForkedJobletExecutor<T,JobletConfigMetadata,Integer> get(DaemonNotifier notifier, String tmpPath, int maxProcesses, Class<? extends JobletFactory<T>> jobletFactoryClass, Map<String, String> envVariables, JobletCallback<? super T> successCallback, JobletCallback<? super T> failureCallback, ProcessJobletRunner<Integer> jobletRunner) throws IOException, IllegalAccessException, InstantiationException {
+    public static <T extends JobletConfig> ForkedJobletExecutor<T, JobletConfigMetadata, Integer> get(DaemonNotifier notifier, String tmpPath, int maxProcesses, Class<? extends JobletFactory<T>> jobletFactoryClass, Map<String, String> envVariables, JobletCallback<? super T> successCallback, JobletCallback<? super T> failureCallback, ProcessJobletRunner<Integer> jobletRunner) throws IOException, IllegalAccessException, InstantiationException {
       Preconditions.checkArgument(hasNoArgConstructor(jobletFactoryClass), String.format("Class %s has no accessible no-arg constructor", jobletFactoryClass.getName()));
 
       File pidDir = new File(tmpPath, "pids");
@@ -52,7 +52,7 @@ public class JobletExecutors {
           notifier,
           new FsHelper(pidDir.getPath()),
           new LocalProcessPidProcessor(),
-          new JobletProcessHandler<T, Integer, JobletConfigMetadata>(successCallback, failureCallback, configStore, jobletStatusManager),
+          new JobletProcessHandler<>(successCallback, failureCallback, configStore, jobletStatusManager),
           new PsRunningProcessGetter(),
           DEFAULT_POLL_DELAY,
           new JobletConfigMetadata.Serializer()
@@ -73,7 +73,7 @@ public class JobletExecutors {
       return get(maxActiveJoblets, jobletFactoryClass.newInstance(), successCallbacks, failureCallbacks);
     }
 
-    public static <T extends JobletConfig> ThreadedJobletExecutor<T> get(int maxActiveJoblets, JobletFactory<T> jobletFactory, JobletCallback<T> successCallbacks, JobletCallback<T> failureCallbacks) throws IllegalAccessException, InstantiationException {
+    public static <T extends JobletConfig> ThreadedJobletExecutor<T> get(int maxActiveJoblets, JobletFactory<T> jobletFactory, JobletCallback<? super T> successCallbacks, JobletCallback<? super T> failureCallbacks) throws IllegalAccessException, InstantiationException {
       Preconditions.checkNotNull(jobletFactory);
       Preconditions.checkArgument(maxActiveJoblets > 0);
 

--- a/src/main/java/com/liveramp/daemon_lib/executors/ThreadedJobletExecutor.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/ThreadedJobletExecutor.java
@@ -18,10 +18,10 @@ public class ThreadedJobletExecutor<T extends JobletConfig> implements JobletExe
 
   private final ThreadPoolExecutor threadPool;
   private final JobletFactory<T> jobletFactory;
-  private final JobletCallback<T> successCallback;
-  private final JobletCallback<T> failureCallback;
+  private final JobletCallback<? super T> successCallback;
+  private final JobletCallback<? super T> failureCallback;
 
-  public ThreadedJobletExecutor(ThreadPoolExecutor threadPool, JobletFactory<T> jobletFactory, JobletCallback<T> successCallback, JobletCallback<T> failureCallback) {
+  public ThreadedJobletExecutor(ThreadPoolExecutor threadPool, JobletFactory<T> jobletFactory, JobletCallback<? super T> successCallback, JobletCallback<? super T> failureCallback) {
     this.threadPool = threadPool;
     this.jobletFactory = jobletFactory;
     this.successCallback = successCallback;

--- a/src/main/java/com/liveramp/daemon_lib/utils/JobletCallbackUtil.java
+++ b/src/main/java/com/liveramp/daemon_lib/utils/JobletCallbackUtil.java
@@ -9,25 +9,25 @@ import com.liveramp.daemon_lib.JobletConfig;
 public class JobletCallbackUtil {
 
   @SafeVarargs
-  public static <T extends JobletConfig> JobletCallback<T> compose(JobletCallback<T>... callbacks) {
+  public static <T extends JobletConfig> JobletCallback<T> compose(JobletCallback<? super T>... callbacks) {
     return new ComposeJobletCallback<>(Arrays.asList(callbacks));
   }
 
-  public static <T extends JobletConfig> JobletCallback<T> compose(List<JobletCallback<T>> callbacks) {
+  public static <T extends JobletConfig> JobletCallback<T> compose(List<JobletCallback<? super T>> callbacks) {
     return new ComposeJobletCallback<>(callbacks);
   }
 
   static class ComposeJobletCallback<T extends JobletConfig> implements JobletCallback<T> {
 
-    private final List<JobletCallback<T>> callbacks;
+    private final List<JobletCallback<? super T>> callbacks;
 
-    ComposeJobletCallback(List<JobletCallback<T>> callbacks) {
+    ComposeJobletCallback(List<JobletCallback<? super T>> callbacks) {
       this.callbacks = callbacks;
     }
 
     @Override
     public void callback(T config) throws DaemonException {
-      for (JobletCallback<T> callback : callbacks) {
+      for (JobletCallback<? super T> callback : callbacks) {
         callback.callback(config);
       }
     }


### PR DESCRIPTION
This pull request creates three more abstract daemon builders between the `BaseDaemonBuilder` and the forking, threading and blocking daemon builder implementations. This change will allow further customization of the different daemon builders. For example, a new forking daemon builder implementation can extend from `BaseForkingDaemonBuilder` and have default callbacks, config producer, and joblet factory so that users can create a more standard forking daemon with little amount of code.

@lancehc, can you take a look?

In addition, I also added a travis-ci yaml config for this repo. But I don't have admin access, so can someone activate travis for this project?
