### PR TITLE
Fail in more cases

### DIFF
--- a/src/main/java/com/liveramp/daemon_lib/executors/forking/ForkedJobletRunner.java
+++ b/src/main/java/com/liveramp/daemon_lib/executors/forking/ForkedJobletRunner.java
@@ -36,8 +36,10 @@ public class ForkedJobletRunner {
     String id = args[3];
     String customSerializationClasses = args.length > 4 ? args[4] : "";
 
-    JobletFactory factory = (JobletFactory)Class.forName(jobletFactoryClassName).newInstance();
     DefaultJobletStatusManager jobletStatusManager = new DefaultJobletStatusManager(daemonWorkingDir);
+    jobletStatusManager.start(id);
+
+    JobletFactory factory = (JobletFactory)Class.forName(jobletFactoryClassName).newInstance();
     final List<Function<byte[], ? extends JobletConfig>> deserializersWithDefault = Stream.concat(
         Stream.of(customSerializationClasses.split(";")).map(ForkedJobletRunner::getInstanceOfDeserializer),
         Stream.of(JobletConfigStorage.getDefaultDeserializer()))
@@ -48,7 +50,6 @@ public class ForkedJobletRunner {
         new CompositeDeserializer<>(deserializersWithDefault))
         .loadConfig(id);
 
-    jobletStatusManager.start(id);
     Joblet joblet = factory.create(config);
     joblet.run();
     jobletStatusManager.complete(id);

--- a/src/main/java/com/liveramp/daemon_lib/utils/JobletProcessHandler.java
+++ b/src/main/java/com/liveramp/daemon_lib/utils/JobletProcessHandler.java
@@ -61,6 +61,7 @@ public class JobletProcessHandler<T extends JobletConfig, Pid, M extends Process
       }
     } else {
       LOG.info("No Managed Status Found - PID: " + watchedProcess.getPid());
+      failureCallback.callback(jobletConfig);
     }
   }
 }


### PR DESCRIPTION
Two changes that should address a couple of failure modes shown recently:

* When removing a process, fail the config for that process if a status doesn't exist:

This makes sense, if the status didn't get tracked, and the process is gone, that's clearly a failure. The only time there's a success is if the status was tracked, was `DONE`, and the process is gone.

* Update the status in the `ForkedJobletRunner` before doing anything

We should do this anyway, because it's the right thing to do, but even if this were out of order, the other would (and should) catch it.