### PR TITLE
Add a ThreadContextClassloader as one of the defaults

### DIFF
--- a/src/main/java/com/liveramp/daemon_lib/serialization/ThreadContextClassloaderDeserializer.java
+++ b/src/main/java/com/liveramp/daemon_lib/serialization/ThreadContextClassloaderDeserializer.java
@@ -1,0 +1,19 @@
+package com.liveramp.daemon_lib.serialization;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.function.Function;
+
+import org.apache.commons.lang.SerializationUtils;
+
+public class ThreadContextClassloaderDeserializer<T> implements Function<byte[], T> {
+  @SuppressWarnings("unchecked")
+  @Override
+  public T apply(byte[] bytes) {
+    try {
+      return (T)SerializationUtils.deserialize(new ThreadContextClassloaderObjectInputStream(new ByteArrayInputStream(bytes)));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/com/liveramp/daemon_lib/serialization/ThreadContextClassloaderObjectInputStream.java
+++ b/src/main/java/com/liveramp/daemon_lib/serialization/ThreadContextClassloaderObjectInputStream.java
@@ -1,0 +1,18 @@
+package com.liveramp.daemon_lib.serialization;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+
+public class ThreadContextClassloaderObjectInputStream extends ObjectInputStream {
+
+  public ThreadContextClassloaderObjectInputStream(InputStream in) throws IOException {
+    super(in);
+  }
+
+  @Override
+  protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+    return Thread.currentThread().getContextClassLoader().loadClass(desc.getName());
+  }
+}

--- a/src/main/java/com/liveramp/daemon_lib/utils/JobletConfigStorage.java
+++ b/src/main/java/com/liveramp/daemon_lib/utils/JobletConfigStorage.java
@@ -9,8 +9,10 @@ import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 
 import com.liveramp.daemon_lib.JobletConfig;
+import com.liveramp.daemon_lib.built_in.CompositeDeserializer;
 import com.liveramp.daemon_lib.serialization.JavaObjectDeserializer;
 import com.liveramp.daemon_lib.serialization.JavaObjectSerializer;
+import com.liveramp.daemon_lib.serialization.ThreadContextClassloaderDeserializer;
 
 public class JobletConfigStorage<T extends JobletConfig> {
   public static final Function<JobletConfig, byte[]> DEFAULT_SERIALIZER = new JavaObjectSerializer<>();
@@ -89,7 +91,7 @@ public class JobletConfigStorage<T extends JobletConfig> {
   @SuppressWarnings("unchecked")
   @NotNull
   public static <T extends JobletConfig> Function<byte[], T> getDefaultDeserializer() {
-    return new JavaObjectDeserializer<>();
+    return new CompositeDeserializer<>(new JavaObjectDeserializer<>(), new ThreadContextClassloaderDeserializer<>());
   }
 
 }


### PR DESCRIPTION
This is to prevent the odd situation where an implosion occurs when the default Classloader doesn't have the user classes in it.