### PR TITLE
Try deserializers in same order in Daemon as in Runner

### DIFF
--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseForkingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseForkingDaemonBuilder.java
@@ -41,7 +41,7 @@ public abstract class BaseForkingDaemonBuilder<T extends JobletConfig, E extends
     maxProcesses = DEFAULT_MAX_PROCESSES;
     envVariables = DEFAULT_ENV_VARS;
     serializer = JobletConfigStorage.DEFAULT_SERIALIZER;
-    deserializers = Lists.newArrayList(JobletConfigStorage.getDefaultDeserializer());
+    deserializers = Lists.newArrayList();
   }
 
   public E setMaxProcesses(int maxProcesses) {
@@ -67,6 +67,7 @@ public abstract class BaseForkingDaemonBuilder<T extends JobletConfig, E extends
   @NotNull
   @Override
   protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
+    deserializers.add(JobletConfigStorage.getDefaultDeserializer());
     final String tmpPath = new File(workingDir, identifier).getPath();
     return JobletExecutors.Forked.get(notifier, tmpPath, maxProcesses, jobletFactoryClass, envVariables, successCallback, failureCallback, jobletRunner, serializer, new CompositeDeserializer<>(deserializers));
   }

--- a/src/main/java/com/liveramp/daemon_lib/builders/BaseForkingDaemonBuilder.java
+++ b/src/main/java/com/liveramp/daemon_lib/builders/BaseForkingDaemonBuilder.java
@@ -67,9 +67,10 @@ public abstract class BaseForkingDaemonBuilder<T extends JobletConfig, E extends
   @NotNull
   @Override
   protected JobletExecutor<T> getExecutor() throws IllegalAccessException, IOException, InstantiationException {
-    deserializers.add(JobletConfigStorage.getDefaultDeserializer());
+    List<Function<byte[], ? extends T>> deserializersWithDefault = Lists.newArrayList(deserializers);
+    deserializersWithDefault.add(JobletConfigStorage.getDefaultDeserializer());
     final String tmpPath = new File(workingDir, identifier).getPath();
-    return JobletExecutors.Forked.get(notifier, tmpPath, maxProcesses, jobletFactoryClass, envVariables, successCallback, failureCallback, jobletRunner, serializer, new CompositeDeserializer<>(deserializers));
+    return JobletExecutors.Forked.get(notifier, tmpPath, maxProcesses, jobletFactoryClass, envVariables, successCallback, failureCallback, jobletRunner, serializer, new CompositeDeserializer<>(deserializersWithDefault));
   }
 
 }


### PR DESCRIPTION
https://github.com/LiveRamp/daemon_lib/pull/14 revealed a bug in the ordering of custom deserializers on the Daemon side. The joblet runner correctly falls back finally to the default deserializer. However, the Daemon side starts with the default deserializer. This isn't a problem when the default fails (though it is silly to have it always fail first before the correct one kicks in), but when the default never fails, we incorrectly interpret the serialized config.