### PR TITLE
Daemon.start no longer final

### DIFF
--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -100,7 +100,7 @@ public class Daemon<T extends JobletConfig> {
     return identifier.replaceAll("\\s", "-");
   }
 
-  public final void start() {
+  public void start() {
     LOG.info("Running open-source version of daemon_lib");
     LOG.info("Starting daemon {}", getDaemonSignature());
     running = true;


### PR DESCRIPTION
From the other discussion, there doesn't seem to be any good reason why we shouldn't allow overriding this

@pwestling 