### PR TITLE
Adjust default waiting time

### DIFF
--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -16,9 +16,9 @@ import com.liveramp.daemon_lib.utils.HostUtil;
 public class Daemon<T extends JobletConfig> {
   private static final Logger LOG = LoggerFactory.getLogger(Daemon.class);
 
-  private static final int DEFAULT_CONFIG_WAIT_SECONDS = 1;
-  private static final int DEFAULT_EXECUTION_SLOT_WAIT_SECONDS = 0;
-  private static final int DEFAULT_NEXT_CONFIG_WAIT_SECONDS = 0;
+  private static final int DEFAULT_CONFIG_WAIT_SECONDS = 5;
+  private static final int DEFAULT_EXECUTION_SLOT_WAIT_SECONDS = 5;
+  private static final int DEFAULT_NEXT_CONFIG_WAIT_SECONDS = 5;
   private static final int DEFAULT_FAILURE_WAIT_SECONDS = 10;
 
   public static class Options {


### PR DESCRIPTION
Some of the default waiting time seems too short. Continuously querying the database (or whatever underlying persistence) is not reasonable nor necessary in my opinion. This has already caused enough grief in many of our daemons.

But feel free to close this PR if anyone disagrees.
