### PR TITLE
adds attempt to call failure callback on internal exception; adds tes…

### DIFF
--- a/src/main/java/com/liveramp/daemon_lib/utils/JobletProcessHandler.java
+++ b/src/main/java/com/liveramp/daemon_lib/utils/JobletProcessHandler.java
@@ -45,7 +45,12 @@ public class JobletProcessHandler<T extends JobletConfig, Pid, M extends Process
       try {
         status = jobletStatusManager.getStatus(identifier);
       } catch (Exception e) {
-        status = JobletStatus.IN_PROGRESS;
+        try {
+          failureCallback.callback(jobletConfig);
+        } catch (Exception callbackException) {
+          throw new DaemonException("Failure callback triggered due to an exception in jobletStatusManager. Failure callback, however, also failed.", callbackException);
+        }
+        throw e;
       }
 
       try {

--- a/src/main/java/com/liveramp/daemon_lib/utils/JobletProcessHandler.java
+++ b/src/main/java/com/liveramp/daemon_lib/utils/JobletProcessHandler.java
@@ -41,8 +41,14 @@ public class JobletProcessHandler<T extends JobletConfig, Pid, M extends Process
     }
 
     if (jobletStatusManager.exists(identifier)) {
+      JobletStatus status;
       try {
-        JobletStatus status = jobletStatusManager.getStatus(identifier);
+        status = jobletStatusManager.getStatus(identifier);
+      } catch (Exception e) {
+        status = JobletStatus.IN_PROGRESS;
+      }
+
+      try {
         switch (status) {
           case DONE:
             LOG.info("Process succeeded - PID: " + watchedProcess.getPid());

--- a/src/test/java/com/liveramp/daemon_lib/utils/TestJobletProcessHandler.java
+++ b/src/test/java/com/liveramp/daemon_lib/utils/TestJobletProcessHandler.java
@@ -77,9 +77,14 @@ public class TestJobletProcessHandler {
   }
 
   @Test
-  public void testOnRemoveAttemptsFailureCallbackOnException() throws DaemonException {
+  public void testOnRemoveAttemptsFailureCallbackOnExceptionThenReThrows() throws DaemonException {
     when(jobletStatusManager.getStatus(IDENTIFIER)).thenThrow(new IllegalArgumentException());
-    jobletProcessHandler.onRemove(processDefinition);
+    try {
+      jobletProcessHandler.onRemove(processDefinition);
+      Assert.fail();
+    } catch (IllegalArgumentException ignored) {
+
+    }
     verify(failureCallback, times(1)).callback(jobletConfig);
   }
 

--- a/src/test/java/com/liveramp/daemon_lib/utils/TestJobletProcessHandler.java
+++ b/src/test/java/com/liveramp/daemon_lib/utils/TestJobletProcessHandler.java
@@ -1,0 +1,98 @@
+package com.liveramp.daemon_lib.utils;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.liveramp.daemon_lib.JobletCallback;
+import com.liveramp.daemon_lib.JobletConfig;
+import com.liveramp.daemon_lib.executors.processes.ProcessDefinition;
+import com.liveramp.daemon_lib.executors.processes.ProcessMetadata;
+import com.liveramp.daemon_lib.tracking.JobletStatus;
+import com.liveramp.daemon_lib.tracking.JobletStatusManager;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+@RunWith(MockitoJUnitRunner.class)
+public class TestJobletProcessHandler {
+  private final String IDENTIFIER = "id";
+
+  @Mock
+  private JobletCallback successCallback;
+
+  @Mock
+  private JobletCallback failureCallback;
+
+  @Mock
+  private JobletConfigStorage jobletConfigStorage;
+
+  @Mock
+  private JobletStatusManager jobletStatusManager;
+
+  @Mock
+  private ProcessDefinition processDefinition;
+
+  @Mock
+  private ProcessMetadata processMetadata;
+
+  @Mock
+  private JobletConfig jobletConfig;
+
+  private JobletProcessHandler jobletProcessHandler;
+
+  @Before
+  public void setup() throws IOException, ClassNotFoundException {
+    when(processDefinition.getMetadata()).thenReturn(processMetadata);
+    when(processMetadata.getIdentifier()).thenReturn(IDENTIFIER);
+
+    when(jobletConfigStorage.loadConfig(IDENTIFIER)).thenReturn(jobletConfig);
+
+    when(jobletStatusManager.exists(IDENTIFIER)).thenReturn(true);
+
+    jobletProcessHandler = new JobletProcessHandler<>(successCallback, failureCallback, jobletConfigStorage, jobletStatusManager);
+  }
+
+
+  @Test
+  public void testOnRemoveAttemptsSuccessCallbackWhenStatusIsDone() throws DaemonException {
+    when(jobletStatusManager.getStatus(IDENTIFIER)).thenReturn(JobletStatus.DONE);
+    jobletProcessHandler.onRemove(processDefinition);
+    verify(successCallback, times(1)).callback(jobletConfig);
+  }
+
+  @Test
+  public void testOnRemoveAttemptsFailureCallbackWhenStatusIsInProgress() throws DaemonException {
+    when(jobletStatusManager.getStatus(IDENTIFIER)).thenReturn(JobletStatus.IN_PROGRESS);
+    jobletProcessHandler.onRemove(processDefinition);
+    verify(failureCallback, times(1)).callback(jobletConfig);
+  }
+
+  @Test
+  public void testOnRemoveAttemptsFailureCallbackOnException() throws DaemonException {
+    when(jobletStatusManager.getStatus(IDENTIFIER)).thenThrow(new IllegalArgumentException());
+    jobletProcessHandler.onRemove(processDefinition);
+    verify(failureCallback, times(1)).callback(jobletConfig);
+  }
+
+  @Test
+  public void testOnRemoveAttemptsFailureCallbackOnExceptionAndStillFails() throws DaemonException {
+    when(jobletStatusManager.getStatus(IDENTIFIER)).thenThrow(new IllegalArgumentException());
+    doThrow(new RuntimeException()).when(failureCallback).callback(jobletConfig);
+    try {
+      jobletProcessHandler.onRemove(processDefinition);
+      Assert.fail();
+    } catch (DaemonException ignored) {
+
+    }
+  }
+
+}


### PR DESCRIPTION
* adds attempt to call failure callback on internal exception
* adds tests to JobletProcessHandler

in the case where the call to `jobletStatusManager.getStatus(identifier)` fails, the process dies without attempting to call failure callbacks. i don't think this behavior is very intuitive, because it does not allow the caller to realize that there's a problem. i'd prefer that in such a case daemon tries to call my failure callback. what do you guys think?