### PR TITLE
add wakeup callback to daemon

### DIFF
--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -142,7 +142,7 @@ public class Daemon<T extends JobletConfig> {
 
   protected boolean processNext() {
     try {
-      wakeUpCallback.call();
+      wakeUpCallback.run();
     } catch (Exception e) {
       notifier.notify("Error executing wakeUpCallback for daemon (" + getDaemonSignature() + ")",
           Optional.of(wakeUpCallback.toString()),

--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -142,8 +142,8 @@ public class Daemon<T extends JobletConfig> {
 
   protected boolean processNext() {
     try {
-      wakeUpCallback.callback();
-    } catch (DaemonException e) {
+      wakeUpCallback.call();
+    } catch (Exception e) {
       notifier.notify("Error executing wakeUpCallback for daemon (" + getDaemonSignature() + ")",
           Optional.of(wakeUpCallback.toString()),
           Optional.of(e));

--- a/src/main/java/com/liveramp/daemon_lib/DaemonCallback.java
+++ b/src/main/java/com/liveramp/daemon_lib/DaemonCallback.java
@@ -1,0 +1,17 @@
+package com.liveramp.daemon_lib;
+
+import com.liveramp.daemon_lib.utils.DaemonException;
+
+public interface DaemonCallback {
+
+  void callback() throws DaemonException;
+
+  class None implements DaemonCallback {
+
+    @Override
+    public void callback() throws DaemonException {
+
+    }
+  }
+
+}

--- a/src/main/java/com/liveramp/daemon_lib/DaemonCallback.java
+++ b/src/main/java/com/liveramp/daemon_lib/DaemonCallback.java
@@ -1,13 +1,11 @@
 package com.liveramp.daemon_lib;
 
-import java.util.concurrent.Callable;
-
-public interface DaemonCallback extends Callable<Void> {
+public interface DaemonCallback extends Runnable {
 
   class None implements DaemonCallback {
     @Override
-    public Void call() {
-      return null;
+    public void run() {
+
     }
   }
 

--- a/src/main/java/com/liveramp/daemon_lib/DaemonCallback.java
+++ b/src/main/java/com/liveramp/daemon_lib/DaemonCallback.java
@@ -1,16 +1,13 @@
 package com.liveramp.daemon_lib;
 
-import com.liveramp.daemon_lib.utils.DaemonException;
+import java.util.concurrent.Callable;
 
-public interface DaemonCallback {
-
-  void callback() throws DaemonException;
+public interface DaemonCallback extends Callable<Void> {
 
   class None implements DaemonCallback {
-
     @Override
-    public void callback() throws DaemonException {
-
+    public Void call() {
+      return null;
     }
   }
 


### PR DESCRIPTION
This PR adds a callback to Daemon that is executed every time the daemon wakes up to look for new configs. One example use case of this (which is my motivation for adding it) is to add a sort of heartbeat monitor to our daemons. This would just be a small callback that pushes something to datadog whenever the daemon wakes up, so that we know that our daemons are running. We would have an alert that would go off if no heartbeats have been received from a daemon for an hour, for instance. 

We recently had an OC issue where someone had accidentally killed a daemon and we didnt realize that it had not been running for half a day. This heartbeat would solve that and make us a lot more confident that our apps are running correctly.