### PR TITLE
Release the daemon lock asap

### DIFF
--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -130,8 +130,9 @@ public class Daemon<T extends JobletConfig> {
         jobletConfig = configProducer.getNextConfig();
       } catch (DaemonException e) {
         notifier.notify("Error getting next config for daemon (" + getDaemonSignature() + ")", Optional.empty(), Optional.of(e));
-        lock.unlock();
         return false;
+      } finally {
+        lock.unlock();
       }
       ExecutionContext<T> executionContext;
       if (this.running && jobletConfig != null && configBasedExecutionCondition.apply(jobletConfig)) {
@@ -144,8 +145,6 @@ public class Daemon<T extends JobletConfig> {
               Optional.of(jobletConfig.toString() + "\n" + preExecutionCallback.toString()),
               Optional.of(e));
           return false;
-        } finally {
-          lock.unlock();
         }
         try {
           executor.execute(executionContext);
@@ -156,7 +155,6 @@ public class Daemon<T extends JobletConfig> {
           return false;
         }
       } else {
-        lock.unlock();
         silentSleep(options.configWaitSeconds);
       }
     } else {

--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -142,12 +142,13 @@ public class Daemon<T extends JobletConfig> {
     } catch (DaemonException e) {
       notifier.notify("Error getting next config for daemon (" + getDaemonSignature() + ")", Optional.empty(),
           Optional.of(e));
-      return false;
-    } finally {
       lock.unlock();
+      return false;
     }
+
     ExecutionContext<T> executionContext;
     if (!(this.running && jobletConfig != null && configBasedExecutionCondition.apply(jobletConfig))) {
+      lock.unlock();
       silentSleep(options.configWaitSeconds);
       return true;
     }
@@ -162,6 +163,8 @@ public class Daemon<T extends JobletConfig> {
           Optional.of(jobletConfig.toString() + "\n" + preExecutionCallback.toString()),
           Optional.of(e));
       return false;
+    } finally {
+      lock.unlock();
     }
 
     try {


### PR DESCRIPTION
The main motivation for this change is to allow the Daemon level locking to be non-blocking. Lets look [at the code here](https://github.com/LiveRamp/daemon_lib/blob/80c168bc6fcd2813acd41203b1cafe7a237479f9/src/main/java/com/liveramp/daemon_lib/Daemon.java#L125-L167):

```java
  protected boolean processNext() {
    if (executionCondition.canExecute()) {
      T jobletConfig;
      try {
        lock.lock();
        jobletConfig = configProducer.getNextConfig();
      } catch (DaemonException e) {
        notifier.notify("Error getting next config for daemon (" + getDaemonSignature() + ")", Optional.empty(), Optional.of(e));
        lock.unlock();
        return false;
      }
      ExecutionContext<T> executionContext;
      if (this.running && jobletConfig != null && configBasedExecutionCondition.apply(jobletConfig)) {
        LOG.info("Found joblet config: " + jobletConfig);
        try {
          executionContext = executor.createContext(jobletConfig);
          preExecutionCallback.callback(jobletConfig);
        } catch (DaemonException e) {
          notifier.notify("Error executing callbacks for daemon (" + getDaemonSignature() + ")",
              Optional.of(jobletConfig.toString() + "\n" + preExecutionCallback.toString()),
              Optional.of(e));
          return false;
        } finally {
          lock.unlock();
        }
        try {
          executor.execute(executionContext);
        } catch (Exception e) {
          notifier.notify("Error executing joblet config for daemon (" + getDaemonSignature() + ")",
              Optional.of(jobletConfig.toString()),
              Optional.of(e));
          return false;
        }
      } else {
        lock.unlock();
        silentSleep(options.configWaitSeconds);
      }
    } else {
      silentSleep(options.executionSlotWaitSeconds);
    }

    return true;
  }
```

The main issue is this lock (called the daemon lock). When we spin up a large number of daemons (numbering in the hundreds), all the newly created daemons block on this lock. When a daemon obtains the lock, it fetches a joblet config, executes the joblet and then releases the lock. Therefore, the duration for which the lock is held is unpredictable.

This situation really becomes exacerbated when:
* _the joblets take a really long time to complete_ this can happen often as many daemons are used as coordinators for big data workloads and thus they take a long time to complete.
* _daemons are scaled up_ this can happen during auto or manual scaling in response to heavy workloads.

(*Liveramp Internal Note*: We have observed this issue specifically in [INGEST-2558](https://liveramp.atlassian.net/browse/INGEST-2558).)

So the question is: _is this lock really required_? And the answer is _only to obtain the joblet config, not for the duration of joblet processing_. The lock is useful because [it allows one daemon at a time to get a joblet config](https://github.com/LiveRamp/daemon_lib/commit/5c5c0fb839e2f6b6775b38bdaba0d8bc3967d75d). Once the config is obtained from the config producer, there is no need to hold on to the lock anymore.

Therefore, in this change we unlock as soon as the config is obtained from the configproducer. 
