### PR TITLE
Daemon should not produce a config if not running

### DIFF
--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -127,6 +127,9 @@ public class Daemon<T extends JobletConfig> {
       T jobletConfig;
       try {
         lock.lock();
+        if (!this.running) {
+          return false;
+        }
         jobletConfig = configProducer.getNextConfig();
       } catch (DaemonException e) {
         notifier.notify("Error getting next config for daemon (" + getDaemonSignature() + ")", Optional.empty(), Optional.of(e));

--- a/src/main/java/com/liveramp/daemon_lib/Daemon.java
+++ b/src/main/java/com/liveramp/daemon_lib/Daemon.java
@@ -128,6 +128,7 @@ public class Daemon<T extends JobletConfig> {
       try {
         lock.lock();
         if (!this.running) {
+          lock.unlock();
           return false;
         }
         jobletConfig = configProducer.getNextConfig();


### PR DESCRIPTION
If the daemon is Terminating, we shouldn't try to produce a config. This is a minor optimization in most cases, but can be a big speedup for more complex daemons.