### PR TITLE
DEV-6236: Test K8s pod agent (k8s-test-2204-8)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 #!groovy
-@Library("liveramp-base@v2") _
+@Library("liveramp-base@DEV-6236/k8s-shared-library") _
 
 env.JAVA_HOME = '/usr/lib/jvm/java-8-openjdk-amd64'
 
-mvnBuildPipeline {
-    agentLabel = 'jenkins-agent-hub-ubuntu-2204-n1-standard-8'
+mvnBuildPipelineK8s {
+    agentLabel = 'k8s-test-2204-8'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 #!groovy
-@Library("liveramp-base@DEV-6236/k8s-shared-library") _
+@Library("liveramp-base@v2") _
 
 env.JAVA_HOME = '/usr/lib/jvm/java-8-openjdk-amd64'
 
-mvnBuildPipelineK8s {
+mvnBuildPipeline {
     agentLabel = 'k8s-test-2204-8'
 }


### PR DESCRIPTION
## Jira
https://liveramp.atlassian.net/browse/DEV-6236

## Summary
Test PR to validate the new common K8s pod agent (`k8s-test-2204-8`) as a drop-in replacement for the GCE Jenkins agent `jenkins-agent-hub-ubuntu-2204-n1-standard-8`.

## Changes
- Points shared library to `DEV-6236/k8s-shared-library` branch (K8s pipeline steps)
- Switches from `mvnBuildPipeline` → `mvnBuildPipelineK8s`
- Replaces `agentLabel = 'jenkins-agent-hub-ubuntu-2204-n1-standard-8'` → `agentLabel = 'k8s-test-2204-8'`

## K8s pod spec (from kubernetes-deployments#6337)
- **jnlp**: `jenkins-agent-2204-k8s:stable` (built by [linux-provisioning#139](https://github.com/LiveRamp/linux-provisioning/pull/139)) — JDK 8/11/17/21, Docker CLI, gcloud, kubectl, Ruby, Node
- **dind sidecar**: `docker:27-dind` privileged — replaces the GCE VM's native Docker daemon

## Test plan
- [ ] Trigger this build manually
- [ ] Confirm pod starts on `k8s-test-2204-8` label (replacing GCE `jenkins-agent-hub-ubuntu-2204-n1-standard-8`)
- [ ] Maven build + test passes with Java 8
- [ ] No regressions vs. GCE baseline

**DO NOT MERGE** — test branch only. Will be closed once K8s agent is validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline build environment selection to optimize build processing and compatibility.
  * Minor pipeline configuration adjustments to align builds with updated infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->