### PR TITLE
Migrate Jenkins build to k8s-test-2204-8 agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@
 env.JAVA_HOME = '/usr/lib/jvm/java-8-openjdk-amd64'
 
 mvnBuildPipeline {
-    agentLabel = 'jenkins-agent-hub-ubuntu-2204-n1-standard-8'
+    agentLabel = 'k8s-test-2204-8'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@
 env.JAVA_HOME = '/usr/lib/jvm/java-8-openjdk-amd64'
 
 mvnBuildPipeline {
-    agentLabel = 'k8s-test-2204-8'
+    agentLabel = 'k8s-migration-test-2204'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 #!groovy
-@Library("liveramp-base@v2") _
+@Library("liveramp-base@DEV-6236/k8s-shared-library") _
 
 env.JAVA_HOME = '/usr/lib/jvm/java-8-openjdk-amd64'
 
-mvnBuildPipeline {
+mvnBuildPipelineK8s {
     agentLabel = 'k8s-migration-test-2204'
 }


### PR DESCRIPTION
## Summary

Migrates `mvnBuildPipeline` from the GCE Ubuntu 22.04 agent (`jenkins-agent-hub-ubuntu-2204-n1-standard-8`) to the new ephemeral Kubernetes pod agent label `k8s-test-2204-8`.

The new agent (cloud `K8S-STD-2204-8`, image `jenkins-agent-2204-k8s:stable`) was added to the prod Hub Services Jenkins controller in [kubernetes-deployments#6337](https://github.com/LiveRamp/kubernetes-deployments/pull/6337). See [K8S-AGENTS-GUIDE.md](https://github.com/LiveRamp/kubernetes-deployments/blob/master/helm/gke/eng-ops-hub-services-prod/eng-ops-hub-dmz/devops/jenkins_template/K8S-AGENTS-GUIDE.md) for the full label list.

## Why
- Fresh pod per build, no leftover workspace state or flaky failures from shared VM state
- No queueing on a fixed pool of GCE VMs
- Builds spin up faster under load (cluster autoscales)

## Notes
- `env.JAVA_HOME = java-8-openjdk-amd64` is preserved; the 2204 image ships Java 8/11/17/21.
- Still on `liveramp-base@v2` (the other migrated libs use `@v3.0`). A library bump is intentionally out of scope here so this PR is one isolated change. The `agentLabel` field is honoured by both `@v2` and `@v3.0`.

## Test plan
- [ ] PR build runs on `k8s-test-2204-8` pod (look for `Running on k8s-test-2204-8-...` in the build log instead of `gce-2204-ubuntu-gen-8-...`)
- [ ] `mvn clean deploy` completes; deploy to Artifactory succeeds
- [ ] JUnit test count matches master baseline (17 tests, 0 failing)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to use a different Maven pipeline implementation and select a different build agent/environment for executing builds.
  * Updated the shared pipeline library reference to a new branch/version used by the pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->